### PR TITLE
docs: render track and transaction-flow diagrams as Mermaid

### DIFF
--- a/docs/ap2-integration/transaction-flow.md
+++ b/docs/ap2-integration/transaction-flow.md
@@ -57,38 +57,72 @@ Two enforcement gates connect the mandate layer to the settlement layer:
 
 ## Flow Diagram
 
-```
-User creates job → User + Merchant sign agreement
-                           ↓
-User: IntentMandate → Merchant: CartMandate → Merchant: sign cart
-                           ↓
-[human-present: User approves cart]  OR  [human-not-present: constraint check]
-                           ↓
-CredProvider: PaymentMandate → User/CredProvider: sign payment
-                           ↓
-                    PAYMENT_SIGNED (mandate complete)
-                           ↓
-User: lock fee (amount = cart total, payee = merchant)
-                           ↓
-Merchant: deliver goods → Evaluator: pass/fail
-                           ↓
-User: settle fee → CLOSED (release to merchant or refund to user)
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant SA as Shopping Agent
+    participant M as Merchant
+    participant CP as Credentials Provider
+    participant S as ARS Server
+    actor E as Evaluator
+
+    U->>S: create job (6 actors, modality, fee/principal terms)
+    Note over S: firewall check:<br/>agent key ≠ credentials provider / payment processor
+    U->>S: AGREEMENT_SIGNED
+    M->>S: AGREEMENT_SIGNED
+    Note over S: phase = TRANSACTION
+
+    rect rgb(238, 243, 252)
+        Note over U,CP: Authorization — mandate track
+        U->>S: IntentMandate (budget, merchants, SKUs, TTL, requires_principal)
+        SA->>M: negotiate cart
+        M->>S: CartMandate proposed, then signed
+        alt human-present
+            U->>S: CART_APPROVED_BY_USER
+        else human-not-present
+            S->>S: constraint engine validates budget / whitelist / SKU / TTL
+        end
+        CP->>S: PaymentMandate (references cart hash)
+        U-->>S: PAYMENT_MANDATE_SIGNED (human-present)
+        CP-->>S: PAYMENT_MANDATE_SIGNED (human-not-present)
+        Note over S: mandate track = PAYMENT_SIGNED
+    end
+
+    rect rgb(240, 248, 240)
+        Note over U,E: Settlement — fee track
+        U->>S: lock fee (amount = cart total, payee = merchant)
+        M->>S: deliver goods (deliverable_ref)
+        E->>S: verdict pass / fail
+        U->>S: settle fee
+        Note over S: pass → release to merchant<br/>fail → refund to user<br/>phase = CLOSED
+    end
 ```
 
 With principal track:
 
-```
-                    PAYMENT_SIGNED
-                           ↓
-              ┌────────────┴────────────┐
-              ↓                         ↓
-    User: lock fee              Merchant: request UW
-              ↓                         ↓
-    Merchant: deliver          UW: decide (premium, collateral)
-              ↓                         ↓
-    Evaluator: verdict         User: pay premium / Merchant: lock collateral
-              ↓                         ↓
-    User: settle fee           Auto-RELEASABLE → principal release
-              ↓                         ↓
-           CLOSED              Collateral auto-handled at fee settlement
+```mermaid
+flowchart TD
+    PS([PAYMENT_SIGNED — mandate complete])
+    PS --> F1[User: lock fee]
+    PS --> P1[Merchant: request UW]
+
+    subgraph fee [Fee track]
+        direction TB
+        F1 --> F2[Merchant: deliver goods]
+        F2 --> F3[Evaluator: pass / fail verdict]
+        F3 --> F4[User: settle fee]
+        F4 --> F5([CLOSED])
+    end
+
+    subgraph principal [Principal track]
+        direction TB
+        P1 --> P2[Underwriter: decide premium + collateral]
+        P2 --> P3[User: pay premium<br/>Merchant: lock collateral]
+        P3 --> P4([RELEASABLE — automatic])
+        P4 --> P5[Settlement layer: release principal]
+        P5 --> P6[Merchant: submit execution evidence]
+    end
+
+    F4 -. collateral resolved in the same operation<br/>release → unlock, refund → slash .-> P3
 ```

--- a/docs/ars-protocol/fee-track.md
+++ b/docs/ars-protocol/fee-track.md
@@ -6,9 +6,16 @@ The fee track manages the primary transaction through escrow. It is active in ev
 
 The fee track progresses through five states:
 
-```
-FEE_AWAIT_LOCK → FEE_ESCROW_LOCKED → FEE_DELIVERED → FEE_SETTLED_RELEASE
-                                                    → FEE_SETTLED_REFUND
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> FEE_AWAIT_LOCK: both parties sign
+    FEE_AWAIT_LOCK --> FEE_ESCROW_LOCKED: requestor locks fee
+    FEE_ESCROW_LOCKED --> FEE_DELIVERED: agent submits deliverable
+    FEE_DELIVERED --> FEE_SETTLED_RELEASE: verdict pass → release to agent
+    FEE_DELIVERED --> FEE_SETTLED_REFUND: verdict fail → refund to requestor
+    FEE_SETTLED_RELEASE --> [*]
+    FEE_SETTLED_REFUND --> [*]
 ```
 
 **FEE_AWAIT_LOCK** is the initial state after both parties sign the agreement. The requestor must lock the fee before any work begins.

--- a/docs/ars-protocol/principal-track.md
+++ b/docs/ars-protocol/principal-track.md
@@ -6,17 +6,32 @@ The principal track adds underwriting protection for high-value or high-risk tra
 
 The principal track has more states than the fee track because it involves multi-party negotiation around risk terms:
 
-```
-Happy path:
-  UW_AWAIT_REQUEST → UW_REVIEW → [PREMIUM_PENDING] → [COLLATERAL_REQUESTED]
-                                                          ↓
-                                                      RELEASABLE (auto)
-                                                          ↓
-                                            EXECUTION_PENDING → EXECUTION_EVIDENCE_SUBMITTED
+```mermaid
+stateDiagram-v2
+    [*] --> UW_AWAIT_REQUEST: agreement bound
+    UW_AWAIT_REQUEST --> UW_REVIEW: agent requests UW
 
-Override path (refused terms):
-  ... → OVERRIDE_PENDING → OVERRIDE_DECIDED → RELEASABLE → ...
+    UW_REVIEW --> PREMIUM_PENDING: approved, premium required
+    UW_REVIEW --> COLLATERAL_REQUESTED: approved, collateral only
+    UW_REVIEW --> RELEASABLE: approved, no terms
+    UW_REVIEW --> OVERRIDE_PENDING: rejected
+
+    PREMIUM_PENDING --> COLLATERAL_REQUESTED: premium paid, collateral required
+    PREMIUM_PENDING --> RELEASABLE: premium paid, no collateral
+    PREMIUM_PENDING --> OVERRIDE_PENDING: premium refused
+
+    COLLATERAL_REQUESTED --> RELEASABLE: collateral locked
+    COLLATERAL_REQUESTED --> OVERRIDE_PENDING: collateral refused
+
+    OVERRIDE_PENDING --> RELEASABLE: requestor overrides (proceed)
+
+    RELEASABLE --> EXECUTION_PENDING: settlement layer releases principal
+    EXECUTION_PENDING --> EXECUTION_EVIDENCE_SUBMITTED: agent submits evidence
+    EXECUTION_EVIDENCE_SUBMITTED --> [*]
 ```
+
+`RELEASABLE` is always reached automatically -- either because coverage terms were satisfied or
+because the requestor's override supplied the authorization. There is no separate approval step.
 
 Several states are conditional. `PREMIUM_PENDING` only appears if the underwriter requires a premium. `COLLATERAL_REQUESTED` only appears if the underwriter requires collateral.
 

--- a/docs/vi-integration/transaction-flow.md
+++ b/docs/vi-integration/transaction-flow.md
@@ -67,55 +67,109 @@ Two enforcement gates connect the credential layer to the settlement layer:
 
 ### Immediate Mode
 
-```
-User creates job → User + Merchant sign agreement
-                           ↓
-CredProvider: L1 → User: L2 (final values) → Network: verify L2
-                           ↓
-                    L2_VERIFIED (credential complete)
-                           ↓
-User: lock fee → Merchant: deliver → Evaluator: pass/fail
-                           ↓
-User: settle fee → CLOSED (release to merchant or refund to user)
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant CP as Credential Provider
+    participant PN as Payment Network
+    participant M as Merchant
+    participant S as ARS Server
+    actor E as Evaluator
+
+    U->>S: create job (7 actors, mode = immediate, ES256 JWKs)
+    U->>S: AGREEMENT_SIGNED
+    M->>S: AGREEMENT_SIGNED
+    Note over S: phase = TRANSACTION
+
+    rect rgb(238, 243, 252)
+        Note over CP,PN: Authorization — credential track
+        CP->>S: L1 issuer credential (binds user ES256 key)
+        U->>S: L2 user mandate (final checkout + payment values)
+        PN->>S: verify L2 (L1 signature, sd_hash binding, expiry)
+        Note over S: credential track = L2_VERIFIED
+    end
+
+    rect rgb(240, 248, 240)
+        Note over U,E: Settlement — fee track
+        U->>S: lock fee (payee = merchant)
+        M->>S: deliver goods
+        E->>S: verdict pass / fail
+        U->>S: settle fee
+        Note over S: pass → release to merchant<br/>fail → refund to user<br/>phase = CLOSED
+    end
 ```
 
 ### Autonomous Mode
 
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant CP as Credential Provider
+    participant A as Agent
+    participant PN as Payment Network
+    participant M as Merchant
+    participant S as ARS Server
+    actor E as Evaluator
+
+    U->>S: create job (7 actors, mode = autonomous, ES256 JWKs)
+    U->>S: AGREEMENT_SIGNED
+    M->>S: AGREEMENT_SIGNED
+    Note over S: firewall check:<br/>agent key ≠ credential provider / payment network
+
+    rect rgb(238, 243, 252)
+        Note over CP,PN: Authorization — credential track
+        CP->>S: L1 issuer credential
+        U->>S: L2 user mandate (constraints + cnf.jwk delegating to agent)
+        PN->>S: verify L2
+        par agent fulfilment
+            A->>S: L3a payment fulfilment (5 min TTL)
+        and
+            A->>S: L3b checkout fulfilment (5 min TTL)
+        end
+        PN->>S: verify chain L1 → L2 → L3a + L3b (+ constraint check)
+        Note over S: credential track = L3_CHAIN_VERIFIED
+    end
+
+    rect rgb(240, 248, 240)
+        Note over U,E: Settlement — fee track
+        U->>S: lock fee (payee = merchant)
+        M->>S: deliver goods
+        E->>S: verdict pass / fail
+        U->>S: settle fee
+        Note over S: phase = CLOSED
+    end
 ```
-User creates job → User + Merchant sign agreement
-                           ↓
-CredProvider: L1 → User: L2 (constraints, delegate to agent)
-                           ↓
-                    Network: verify L2
-                           ↓
-              ┌────────────┴────────────┐
-              ↓                         ↓
-    Agent: L3a (payment)      Agent: L3b (checkout)
-              └────────────┬────────────┘
-                           ↓
-              Network: verify chain (+ constraint check)
-                           ↓
-                    L3_CHAIN_VERIFIED (credential complete)
-                           ↓
-User: lock fee → Merchant: deliver → Evaluator: pass/fail
-                           ↓
-User: settle fee → CLOSED
-```
+
+Selective disclosure applies to the presentations, not to the chain itself: the merchant is served
+`GET /jobs/{id}/credentials/present/merchant` (checkout data only) and the payment network is served
+`GET /jobs/{id}/credentials/present/network` (payment data only).
 
 ### With Principal Track
 
-```
-                    CREDENTIAL COMPLETE
-                           ↓
-              ┌────────────┴────────────┐
-              ↓                         ↓
-    User: lock fee              Merchant: request UW
-              ↓                         ↓
-    Merchant: deliver          UW: decide (premium, collateral)
-              ↓                         ↓
-    Evaluator: verdict         User: pay premium / Merchant: lock collateral
-              ↓                         ↓
-    User: settle fee           Auto-RELEASABLE → principal release
-              ↓                         ↓
-           CLOSED              Collateral auto-handled at fee settlement
+```mermaid
+flowchart TD
+    CC([Credential chain verified<br/>L2_VERIFIED or L3_CHAIN_VERIFIED])
+    CC --> F1[User: lock fee]
+    CC --> P1[Merchant: request UW]
+
+    subgraph fee [Fee track]
+        direction TB
+        F1 --> F2[Merchant: deliver goods]
+        F2 --> F3[Evaluator: pass / fail verdict]
+        F3 --> F4[User: settle fee]
+        F4 --> F5([CLOSED])
+    end
+
+    subgraph principal [Principal track]
+        direction TB
+        P1 --> P2[Underwriter: decide premium + collateral]
+        P2 --> P3[User: pay premium<br/>Merchant: lock collateral]
+        P3 --> P4([RELEASABLE — automatic])
+        P4 --> P5[Settlement layer: release principal]
+        P5 --> P6[Merchant: submit execution evidence]
+    end
+
+    F4 -. collateral resolved in the same operation<br/>release → unlock, refund → slash .-> P3
 ```


### PR DESCRIPTION
Documentation only — prose content is unchanged, only the diagrams are replaced.

## Why

The fee track, principal track, and the AP2/VI transaction flows were drawn as ASCII art in plain fenced code blocks. Two problems:

1. **The wide charts no longer line up.** The principal-track diagram and the two fee/principal parallel-track charts had grown past the point where box-drawing characters track the branches they describe — the `┌────┴────┐` splits in particular no longer sit under the nodes they fork from.
2. **They hide the conditional edges.** The principal track's ASCII version brackets `[PREMIUM_PENDING]` and `[COLLATERAL_REQUESTED]` as "optional" but never draws the edges that skip them. The prose in the same file spells out four distinct paths out of `UW_REVIEW`; the diagram showed one.

GitHub renders Mermaid natively in Markdown, so this is a straight upgrade with no tooling added.

## What changed

| File | Before | After |
|---|---|---|
| `docs/ars-protocol/fee-track.md` | ASCII chain | `stateDiagram-v2` with the pass/fail split labelled |
| `docs/ars-protocol/principal-track.md` | ASCII, 1 path shown | `stateDiagram-v2` with all conditional transitions drawn — no-premium, no-collateral, rejected, both refusal paths into `OVERRIDE_PENDING` |
| `docs/ap2-integration/transaction-flow.md` | 2 ASCII charts | `sequenceDiagram` for end-to-end (authorization and settlement phases visually separated, firewall check and modality branch shown as `alt`), `flowchart TD` for the parallel tracks |
| `docs/vi-integration/transaction-flow.md` | 3 ASCII charts | `sequenceDiagram` for immediate and autonomous modes (L3a/L3b shown as a `par` block, since they are independent), `flowchart TD` for the parallel tracks |

Two clarifying sentences were added alongside diagrams where the picture alone would be ambiguous: that `RELEASABLE` is always reached automatically, and that selective disclosure in VI applies to the presentation endpoints rather than to the chain itself. Both restate what the surrounding prose already says.

## Verification

All 7 diagrams were parsed with `mermaid@11`'s own parser (`mermaid.parse()` under jsdom) — 7 pass, 0 fail. No source files changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjg6HB1Fbt2GkAUvdgyVFJ)_